### PR TITLE
text case is not detected

### DIFF
--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ if (!empty($_REQUEST['hub_mode']) && $_REQUEST['hub_mode'] == 'subscribe' && $_R
             switch ($command) {
 
                 // When bot receive "text"
-                case 'text':
+                case !empty($command):
                     $bot->send(new Message($message['sender']['id'], 'This is a simple text message.'));
                     break;
 


### PR DESCRIPTION
text case is not detected, because when user send message, the command variable will hold that message. thus the case will always falling to default.

this happened when I use your repo and find that my chat always fall to default case.
